### PR TITLE
check-and-set transactions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+  * Support for WATCH / MULTI / EXEC check-and-set transactions through 
+    coroutines.
+ 
+  * Transactions can take a single string for watch_key as well as a 
+    table.
+  
 v2.0.0 (2010-xx-xx)
   * The client library is no longer compatible with Redis 1.0.
 

--- a/README.markdown
+++ b/README.markdown
@@ -48,9 +48,9 @@ redis-lua is a pure Lua client library for the Redis advanced key-value database
 ### Leverage Redis MULTI / EXEC transaction (Redis > 2.0)
 
     local replies = redis:transaction(function(t)
-        p:incrby('counter', 10)
-        p:incrby('counter', 30)
-        p:get('counter')
+        t:incrby('counter', 10)
+        t:incrby('counter', 30)
+        t:get('counter')
     end)
 
 ### Get useful information from the server ###

--- a/README.markdown
+++ b/README.markdown
@@ -53,6 +53,14 @@ redis-lua is a pure Lua client library for the Redis advanced key-value database
         t:get('counter')
     end)
 
+### Leverage WATCH / MULTI / EXEC for check-and-set operations 
+    local replies = redis:check_and_set("key_to_watch", function(t)
+        local val = t:get("key_to_watch")
+        coroutine.yield()
+        t:set("akey", val)
+        t:set("anotherkey", val)
+    end)
+
 ### Get useful information from the server ###
 
     for k,v in pairs(redis:info()) do 

--- a/examples/transaction.lua
+++ b/examples/transaction.lua
@@ -16,6 +16,22 @@ local replies = redis:transaction(function(t)
     t:decrby('counter', 15)
 end)
 
+--check-and-set
+local replies = redis:check_and_set("somekey", function(t)
+    --executed after WATCH but before MULTI
+    local val = t:get("somekey")
+    coroutine.yield()
+    --executing during MUTI block
+    t:set("somekey", val .. "suffix")
+end)
+--alternate form
+local val
+local replies = redis:check_and_set("somekey", function(t)
+    val = t:get("somekey")
+end, function(t)
+    t:set("somekey", val)
+end)
+
 for _, reply in pairs(replies) do
     print('*', reply)
 end

--- a/src/redis.lua
+++ b/src/redis.lua
@@ -375,7 +375,7 @@ do
             for i, v in pairs(queued_parsers) do
                 queued_parsers[i]=nil
             end
-            coro = initialize_transaction(client, watch_keys, block)
+            coro = initialize_transaction(client, watch_keys, block, queued_parsers)
             return reply
         end
         transaction_client.watch = function(...)
@@ -438,9 +438,7 @@ do
         else
             error("Invalid parameters for redis transaction.")
         end
-        print(tostring(block))
         return nil or transaction(client, watch_keys, function(client, ...)
-            print("foobarbar")
             coroutine.yield()
             return block(client, ...) --can't wrap this in pcall because we're in a coroutine.
         end)


### PR DESCRIPTION
Hey, I noticed that your transaction abstraction doesn't let you do [check-and-set operations](http://code.google.com/p/redis/wiki/MultiExecCommand#Check_and_Set_(CAS\)_transactions_using_WATCH) so i added a client_prototype.check_and_set function, using a coroutine or two callback blocks. So you could do something like:

```
redis:check_and_set("foo", function(t)
  --execute after WATCH, before MULTI
  local val = t:get("foo")
  coroutine.yield()
  t:set("foo", val .. val)
end)
```

I'd tried other abstractions, but a coroutine seemed to make good sense. Just in case though, you could also do:

```
local val
redis:check_and_set("foo", function(t)
  --execute after WATCH, before MULTI
  val = t:get("foo")
end, function(t)
  t:set("foo", val .. val)
end)
```

What do you think?
