### PR TITLE
queued_parsers during a transaction

### DIFF
--- a/src/redis.lua
+++ b/src/redis.lua
@@ -410,6 +410,9 @@ do
         transaction_client.multi = function(...)
             coroutine.yield()
         end
+        transaction_client.commands_queued = function()
+            return #queued_parsers
+        end
 
         assert(coroutine.resume(coro, transaction_client))
 

--- a/test/test_client.lua
+++ b/test/test_client.lua
@@ -2170,10 +2170,13 @@ context("Redis commands", function()
                 local val = t:get('foobar')
                 t:multi()
                 assert_response_queued(t:set('discardable', 'bar'))
+				assert_equal(t:commands_queued(), 1)
                 assert_true(t:discard())
                 assert_response_queued(t:ping())
+				assert_equal(t:commands_queued(), 1)
                 assert_response_queued(t:echo('hello'))
                 assert_response_queued(t:echo('redis'))
+				assert_equal(t:commands_queued(), 3)
                 if n>0 then
                     n = n-1
                     redis2:set("foobarr", n)


### PR DESCRIPTION
It'd be useful to either have access to the table, or to be able to see the size of said table anytime during a transaction. Without this, it is impossible to write a full-fledged transaction merging function. I've added 
transaction_client:commands_queued(), but there's probably a cleaner way. What do you think?
