### PR TITLE
workaround for socket / socket.unix conflict

### DIFF
--- a/src/redis.lua
+++ b/src/redis.lua
@@ -735,6 +735,7 @@ local function create_connection(parameters)
     local perform_connection, socket
 
     if parameters.scheme == 'unix' then
+        require 'socket'
         perform_connection, socket = connect_unix, require('socket.unix')
         assert(socket, 'your build of LuaSocket does not support UNIX domain sockets')
     else


### PR DESCRIPTION
See https://gist.github.com/3803669 - Always require-ing socket before socket.unix is the best workaround I could find.
