### PR TITLE
Allow alternative coroutine implementations

### DIFF
--- a/rockspec/redis-lua-scm-1.rockspec
+++ b/rockspec/redis-lua-scm-1.rockspec
@@ -2,7 +2,7 @@ package = "redis-lua"
 version = "scm-1"
 
 source = {
-   url = "git://github.com/saucisson/redis-lua.git"
+   url = "git://github.com/CosyVerif/redis-lua.git"
 }
 
 description = {

--- a/rockspec/redis-lua-scm-1.rockspec
+++ b/rockspec/redis-lua-scm-1.rockspec
@@ -2,7 +2,7 @@ package = "redis-lua"
 version = "scm-1"
 
 source = {
-   url = "git://github.com/nrk/redis-lua.git"
+   url = "git://github.com/saucisson/redis-lua.git"
 }
 
 description = {

--- a/test/test_client.lua
+++ b/test/test_client.lua
@@ -254,6 +254,16 @@ context("Client initialization", function()
         assert_true(client:ping())
     end)
 
+    test("Can use an alternative coroutine implementation", function()
+        local connection = require('socket').tcp()
+        connection:connect(settings.host, settings.port)
+        local coroutine = "alternative"
+
+        local client = redis.connect({ socket = connection, coroutine = coroutine })
+        assert_type(client, 'table')
+        assert_true(client.coroutine == coroutine)
+    end)
+
     test("Can specify a timeout for connecting", function()
         local time, timeout = os.time(), 2;
 


### PR DESCRIPTION
This is required when using `redis-lua` within scheduled coroutines, for instance with `copas`. When using the standard coroutine implementation, yields from the network operations (receive, send) can be caught by the iterators of `redis-lua`, instead of the scheduler.

This patch works together with the construction of a client from a socket: `copas` wrapped sockets can be given to `redis-lua`.

Below are links to:
- [the problem](http://stackoverflow.com/questions/27123966/lua-nested-coroutines)
- [an alternative coroutine implementation](https://github.com/siffiejoe/nested-coroutines) (work in progress)
